### PR TITLE
Put log_error into write_error and the FS_LWT signature

### DIFF
--- a/lib/fuse.mli
+++ b/lib/fuse.mli
@@ -26,7 +26,7 @@ module type IO = sig
 
     val write_ack : request -> unit t
 
-    val write_error : request -> Errno.t -> unit t
+    val write_error : (string -> unit) -> request -> Errno.t -> unit t
   end
 end
 

--- a/lwt/fuse_lwt.mli
+++ b/lwt/fuse_lwt.mli
@@ -6,6 +6,8 @@ module type FS_IO_LWT = Fuse.FS_IO with type 'a IO.t = 'a Lwt.t
 module type FS_LWT = sig
   include Fuse.STATE
 
+  val log_error : string -> unit
+
   module Calls :
     functor(IO : IO_LWT) ->
       FS_IO_LWT with type 'a IO.t = 'a IO.t and type t = t


### PR DESCRIPTION
Before this change, users of the lwt support would not know that an error was triggered on their behalf.
