### PR TITLE
dirent size

### DIFF
--- a/lib/profuse.mli
+++ b/lib/profuse.mli
@@ -917,7 +917,7 @@ module Out : sig
     val of_list :
       host:Host.t ->
       (int * int64 * string * Dirent.File_kind.t) list ->
-      int -> 'a request -> char Ctypes.CArray.t
+      int -> int -> 'a request -> char Ctypes.CArray.t
   end
 
   module Readlink : sig


### PR DESCRIPTION
`Profuse.Out.Dirent.of_list` now accepts a `read_size` parameter and respects it during the construction of a dirent batch message. `FUSE_READDIR` opcode messages now have request and reply descriptions.
