### PR TITLE
Bind some FUSE 7.9-FUSE 7.11 constants

### DIFF
--- a/lib/profuse.ml
+++ b/lib/profuse.ml
@@ -154,113 +154,47 @@ module In = struct
   module Opcode = struct
     module T = T.Opcode
 
-    type t = T.t =
-      (* ro *)
-      | FUSE_LOOKUP (* = 1 *)
-      | FUSE_FORGET (* no reply *)
-      | FUSE_GETATTR
-      (* end ro *)
-
-      | FUSE_SETATTR
-      | FUSE_READLINK
-      | FUSE_SYMLINK
-
-      | FUSE_MKNOD (* = 8 *)
-      | FUSE_MKDIR
-      | FUSE_UNLINK
-      | FUSE_RMDIR
-      | FUSE_RENAME
-      | FUSE_LINK
-
-      (* ro *)
-      | FUSE_OPEN (* = 14 *)
-      | FUSE_READ
-      (* end ro *)
-
-      | FUSE_WRITE
-      | FUSE_STATFS
-
-      (* ro *)
-      | FUSE_RELEASE (* = 18 *) (* 0 reply? *)
-      (* end ro *)
-
-      | FUSE_FSYNC (* = 20 *)
-      | FUSE_SETXATTR
-      | FUSE_GETXATTR
-      | FUSE_LISTXATTR
-      | FUSE_REMOVEXATTR
-      | FUSE_FLUSH (* 0 reply *)
-
-      (* ro *)
-      | FUSE_INIT (* = 26 *)
-      | FUSE_OPENDIR
-      | FUSE_READDIR
-      | FUSE_RELEASEDIR (* 0 reply *)
-      (* end ro *)
-
-      | FUSE_FSYNCDIR (* = 30 *)
-      | FUSE_GETLK
-      | FUSE_SETLK
-      | FUSE_SETLKW
-      | FUSE_ACCESS
-      | FUSE_CREATE
-      | FUSE_INTERRUPT
-      | FUSE_BMAP
-
-      (* ro *)
-      | FUSE_DESTROY (* = 38 *) (* no reply *)
-      (* end ro *)
-
-      (* > 7.8 *)
-      (*| FUSE_IOCTL
-      | FUSE_POLL
-      | FUSE_NOTIFY_REPLY
-      | FUSE_BATCH_FORGET
-      | FUSE_FALLOCATE
-
-      | CUSE_INIT
-      *)
-      | Unknown of int32
+    type t = T.t
 
     let to_string = function
-      | FUSE_LOOKUP -> "FUSE_LOOKUP"
-      | FUSE_FORGET -> "FUSE_FORGET"
-      | FUSE_GETATTR -> "FUSE_GETATTR"
-      | FUSE_SETATTR -> "FUSE_SETATTR"
-      | FUSE_READLINK -> "FUSE_READLINK"
-      | FUSE_SYMLINK -> "FUSE_SYMLINK"
+      | `FUSE_LOOKUP -> "FUSE_LOOKUP"
+      | `FUSE_FORGET -> "FUSE_FORGET"
+      | `FUSE_GETATTR -> "FUSE_GETATTR"
+      | `FUSE_SETATTR -> "FUSE_SETATTR"
+      | `FUSE_READLINK -> "FUSE_READLINK"
+      | `FUSE_SYMLINK -> "FUSE_SYMLINK"
 
-      | FUSE_MKNOD -> "FUSE_MKNOD"
-      | FUSE_MKDIR -> "FUSE_MKDIR"
-      | FUSE_UNLINK -> "FUSE_UNLINK"
-      | FUSE_RMDIR -> "FUSE_RMDIR"
-      | FUSE_RENAME -> "FUSE_RENAME"
-      | FUSE_LINK -> "FUSE_LINK"
-      | FUSE_OPEN -> "FUSE_OPEN"
-      | FUSE_READ -> "FUSE_READ"
-      | FUSE_WRITE -> "FUSE_WRITE"
-      | FUSE_STATFS -> "FUSE_STATFS"
-      | FUSE_RELEASE -> "FUSE_RELEASE"
+      | `FUSE_MKNOD -> "FUSE_MKNOD"
+      | `FUSE_MKDIR -> "FUSE_MKDIR"
+      | `FUSE_UNLINK -> "FUSE_UNLINK"
+      | `FUSE_RMDIR -> "FUSE_RMDIR"
+      | `FUSE_RENAME -> "FUSE_RENAME"
+      | `FUSE_LINK -> "FUSE_LINK"
+      | `FUSE_OPEN -> "FUSE_OPEN"
+      | `FUSE_READ -> "FUSE_READ"
+      | `FUSE_WRITE -> "FUSE_WRITE"
+      | `FUSE_STATFS -> "FUSE_STATFS"
+      | `FUSE_RELEASE -> "FUSE_RELEASE"
 
-      | FUSE_FSYNC -> "FUSE_FSYNC"
-      | FUSE_SETXATTR -> "FUSE_SETXATTR"
-      | FUSE_GETXATTR -> "FUSE_GETXATTR"
-      | FUSE_LISTXATTR -> "FUSE_LISTXATTR"
-      | FUSE_REMOVEXATTR -> "FUSE_REMOVEXATTR"
-      | FUSE_FLUSH -> "FUSE_FLUSH"
-      | FUSE_INIT -> "FUSE_INIT"
-      | FUSE_OPENDIR -> "FUSE_OPENDIR"
-      | FUSE_READDIR -> "FUSE_READDIR"
-      | FUSE_RELEASEDIR -> "FUSE_RELEASEDIR"
-      | FUSE_FSYNCDIR -> "FUSE_FSYNCDIR"
-      | FUSE_GETLK -> "FUSE_GETLK"
-      | FUSE_SETLK -> "FUSE_SETLK"
-      | FUSE_SETLKW -> "FUSE_SETLKW"
-      | FUSE_ACCESS -> "FUSE_ACCESS"
-      | FUSE_CREATE -> "FUSE_CREATE"
-      | FUSE_INTERRUPT -> "FUSE_INTERRUPT"
-      | FUSE_BMAP -> "FUSE_BMAP"
-      | FUSE_DESTROY -> "FUSE_DESTROY"
+      | `FUSE_FSYNC -> "FUSE_FSYNC"
+      | `FUSE_SETXATTR -> "FUSE_SETXATTR"
+      | `FUSE_GETXATTR -> "FUSE_GETXATTR"
+      | `FUSE_LISTXATTR -> "FUSE_LISTXATTR"
+      | `FUSE_REMOVEXATTR -> "FUSE_REMOVEXATTR"
+      | `FUSE_FLUSH -> "FUSE_FLUSH"
+      | `FUSE_INIT -> "FUSE_INIT"
+      | `FUSE_OPENDIR -> "FUSE_OPENDIR"
+      | `FUSE_READDIR -> "FUSE_READDIR"
+      | `FUSE_RELEASEDIR -> "FUSE_RELEASEDIR"
+      | `FUSE_FSYNCDIR -> "FUSE_FSYNCDIR"
+      | `FUSE_GETLK -> "FUSE_GETLK"
+      | `FUSE_SETLK -> "FUSE_SETLK"
+      | `FUSE_SETLKW -> "FUSE_SETLKW"
+      | `FUSE_ACCESS -> "FUSE_ACCESS"
+      | `FUSE_CREATE -> "FUSE_CREATE"
+      | `FUSE_INTERRUPT -> "FUSE_INTERRUPT"
+      | `FUSE_BMAP -> "FUSE_BMAP"
+      | `FUSE_DESTROY -> "FUSE_DESTROY"
 
       (*| FUSE_IOCTL -> "FUSE_IOCTL"
       | FUSE_POLL -> "FUSE_POLL"
@@ -270,12 +204,19 @@ module In = struct
 
       | CUSE_INIT -> "CUSE_INIT"
       *)
-      | Unknown i -> "UnknownOpcode("^(Int32.to_string i)^")"
+      | `Unknown i -> "UnknownOpcode("^(Int32.to_string i)^")"
 
     let returns = function
-      | FUSE_FORGET | FUSE_DESTROY -> false
+      | `FUSE_FORGET | `FUSE_DESTROY -> false
       | _ -> true
 
+    let opcode_of_uint32 : Unsigned.UInt32.t -> Types.In.Opcode.t =
+      let l = List.map (fun (k, v) -> (v, k)) Types.In.Opcode.enum_values in
+      fun i ->
+        try ListLabels.assoc i l
+        with Not_found -> `Unknown (Unsigned.UInt32.to_int32 i)
+
+    and uint32_of_opcode v = ListLabels.assoc v Types.In.Opcode.enum_values
   end
 
   module Hdr = struct
@@ -286,6 +227,7 @@ module In = struct
 
     (* Create a headed packet with count buffer sequentially after header *)
     let packet ~opcode ~unique ~nodeid ~uid ~gid ~pid ~count =
+      let opcode = Opcode.uint32_of_opcode opcode in
       let bodysz = count in
       let count = hdrsz + bodysz in
       let pkt = allocate_n char ~count in
@@ -585,74 +527,74 @@ module In = struct
     let unknown i = Unknown i
 
     let parse chan hdr len buf =
-      let opcode = Hdr.(getf hdr T.opcode) in
+      let opcode =  Opcode.opcode_of_uint32 Hdr.(getf hdr T.opcode) in
       {chan; hdr; pkt=Opcode.(match opcode with
-         | FUSE_INIT        -> Init       (!@ (from_voidp Init.T.t buf))
-         | FUSE_GETATTR     -> Getattr
-         | FUSE_LOOKUP      -> Lookup     (coerce (ptr void) string buf)
-         | FUSE_OPENDIR     -> Opendir    (!@ (from_voidp Open.T.t buf))
-         | FUSE_READDIR     -> Readdir    (!@ (from_voidp Read.T.t buf))
-         | FUSE_RELEASEDIR  -> Releasedir (!@ (from_voidp Release.T.t buf))
-         | FUSE_FSYNCDIR    -> Fsyncdir   (!@ (from_voidp Fsync.T.t buf))
-         | FUSE_RMDIR       -> Rmdir      (coerce (ptr void) string buf)
-         | FUSE_MKDIR       ->
+         | `FUSE_INIT        -> Init       (!@ (from_voidp Init.T.t buf))
+         | `FUSE_GETATTR     -> Getattr
+         | `FUSE_LOOKUP      -> Lookup     (coerce (ptr void) string buf)
+         | `FUSE_OPENDIR     -> Opendir    (!@ (from_voidp Open.T.t buf))
+         | `FUSE_READDIR     -> Readdir    (!@ (from_voidp Read.T.t buf))
+         | `FUSE_RELEASEDIR  -> Releasedir (!@ (from_voidp Release.T.t buf))
+         | `FUSE_FSYNCDIR    -> Fsyncdir   (!@ (from_voidp Fsync.T.t buf))
+         | `FUSE_RMDIR       -> Rmdir      (coerce (ptr void) string buf)
+         | `FUSE_MKDIR       ->
            let name = Mkdir.name buf in
            let s = !@ (from_voidp Mkdir.T.t buf) in
            Mkdir (s, name)
-         | FUSE_GETXATTR    -> Getxattr   (!@ (from_voidp Getxattr.T.t buf))
-         | FUSE_SETXATTR    -> Setxattr   (!@ (from_voidp Setxattr.T.t buf))
-         | FUSE_LISTXATTR   -> Listxattr  (!@ (from_voidp Getxattr.T.t buf))
-         | FUSE_REMOVEXATTR -> Removexattr (coerce (ptr void) string buf)
-         | FUSE_ACCESS      -> Access     (!@ (from_voidp Access.T.t buf))
-         | FUSE_FORGET      -> Forget     (!@ (from_voidp Forget.T.t buf))
-         | FUSE_READLINK    -> Readlink
-         | FUSE_OPEN        -> Open       (!@ (from_voidp Open.T.t buf))
-         | FUSE_READ        -> Read       (!@ (from_voidp Read.T.t buf))
-         | FUSE_WRITE       ->
+         | `FUSE_GETXATTR    -> Getxattr   (!@ (from_voidp Getxattr.T.t buf))
+         | `FUSE_SETXATTR    -> Setxattr   (!@ (from_voidp Setxattr.T.t buf))
+         | `FUSE_LISTXATTR   -> Listxattr  (!@ (from_voidp Getxattr.T.t buf))
+         | `FUSE_REMOVEXATTR -> Removexattr (coerce (ptr void) string buf)
+         | `FUSE_ACCESS      -> Access     (!@ (from_voidp Access.T.t buf))
+         | `FUSE_FORGET      -> Forget     (!@ (from_voidp Forget.T.t buf))
+         | `FUSE_READLINK    -> Readlink
+         | `FUSE_OPEN        -> Open       (!@ (from_voidp Open.T.t buf))
+         | `FUSE_READ        -> Read       (!@ (from_voidp Read.T.t buf))
+         | `FUSE_WRITE       ->
            let data = Write.data buf in
            Write (!@ (from_voidp Write.T.t buf), data)
-         | FUSE_STATFS      -> Statfs
-         | FUSE_FLUSH       -> Flush      (!@ (from_voidp Flush.T.t buf))
-         | FUSE_RELEASE     -> Release    (!@ (from_voidp Release.T.t buf))
-         | FUSE_FSYNC       -> Fsync      (!@ (from_voidp Fsync.T.t buf))
-         | FUSE_UNLINK      -> Unlink     (coerce (ptr void) string buf)
-         | FUSE_CREATE      ->
+         | `FUSE_STATFS      -> Statfs
+         | `FUSE_FLUSH       -> Flush      (!@ (from_voidp Flush.T.t buf))
+         | `FUSE_RELEASE     -> Release    (!@ (from_voidp Release.T.t buf))
+         | `FUSE_FSYNC       -> Fsync      (!@ (from_voidp Fsync.T.t buf))
+         | `FUSE_UNLINK      -> Unlink     (coerce (ptr void) string buf)
+         | `FUSE_CREATE      ->
            let name = Create.name buf in
            let s = !@ (from_voidp Create.T.t buf) in
            Create (s, name)
-         | FUSE_MKNOD       ->
+         | `FUSE_MKNOD       ->
            let name = Mknod.name buf in
            let s = !@ (from_voidp Mknod.T.t buf) in
            Mknod (s, name)
-         | FUSE_SETATTR     -> Setattr    (!@ (from_voidp Setattr.T.t buf))
-         | FUSE_LINK        ->
+         | `FUSE_SETATTR     -> Setattr    (!@ (from_voidp Setattr.T.t buf))
+         | `FUSE_LINK        ->
            let name = Link.name buf in
            let s = !@ (from_voidp Link.T.t buf) in
            Link (s, name)
-         | FUSE_SYMLINK     ->
+         | `FUSE_SYMLINK     ->
            let name = coerce (ptr void) string buf in
            let buf =
              to_voidp ((from_voidp char buf) +@ (String.length name + 1))
            in
            let target = coerce (ptr void) string buf in
            Symlink (name,target)
-         | FUSE_RENAME      ->
+         | `FUSE_RENAME      ->
            let (src, dest) = Rename.source_destination buf in
            let s = !@ (from_voidp Rename.T.t buf) in
            Rename (s,src,dest)
-         | FUSE_GETLK       -> Getlk      (!@ (from_voidp Lk.T.t buf))
-         | FUSE_SETLK       -> Setlk      (!@ (from_voidp Lk.T.t buf))
-         | FUSE_SETLKW      -> Setlkw     (!@ (from_voidp Lk.T.t buf))
-         | FUSE_INTERRUPT   -> Interrupt  (!@ (from_voidp Interrupt.T.t buf))
-         | FUSE_BMAP        -> Bmap       (!@ (from_voidp Bmap.T.t buf))
-         | FUSE_DESTROY     -> Destroy
+         | `FUSE_GETLK       -> Getlk      (!@ (from_voidp Lk.T.t buf))
+         | `FUSE_SETLK       -> Setlk      (!@ (from_voidp Lk.T.t buf))
+         | `FUSE_SETLKW      -> Setlkw     (!@ (from_voidp Lk.T.t buf))
+         | `FUSE_INTERRUPT   -> Interrupt  (!@ (from_voidp Interrupt.T.t buf))
+         | `FUSE_BMAP        -> Bmap       (!@ (from_voidp Bmap.T.t buf))
+         | `FUSE_DESTROY     -> Destroy
          (*| FUSE_IOCTL
          | FUSE_POLL
          | FUSE_NOTIFY_REPLY
          | FUSE_BATCH_FORGET
          | FUSE_FALLOCATE
          | CUSE_INIT        -> Other opcode*)
-         | Unknown i        -> unknown i
+         | `Unknown i        -> unknown i
        )}
 
     let string_of_mode req mode =
@@ -674,7 +616,7 @@ module In = struct
       Printf.sprintf "%Ld (%Ld) %s.p%ld.u%ld.g%ld %s"
         (UInt64.to_int64 (getf req.hdr Hdr.unique))
         (UInt64.to_int64 (getf req.hdr Hdr.nodeid))
-        (Opcode.to_string (getf req.hdr Hdr.opcode))
+        (Opcode.to_string (Opcode.opcode_of_uint32 (getf req.hdr Hdr.opcode)))
         (UInt32.to_int32 (getf req.hdr Hdr.pid))
         (UInt32.to_int32 (getf req.hdr Hdr.uid))
         (UInt32.to_int32 (getf req.hdr Hdr.gid))
@@ -1076,58 +1018,58 @@ module Out = struct
     let unknown opcode len buf = Unknown (opcode, len, buf)
 
     let parse ({ chan } as req) hdr len buf =
-      let opcode = In.Hdr.(getf req.hdr T.opcode) in
+      let opcode = In.Opcode.opcode_of_uint32 In.Hdr.(getf req.hdr T.opcode) in
       {chan; hdr; pkt=In.Opcode.(match opcode with
-         | FUSE_INIT        -> Init       (!@ (from_voidp Init.T.t buf))
-         | FUSE_GETATTR     -> Getattr    (!@ (from_voidp Attr.T.t buf))
-         | FUSE_LOOKUP      -> Lookup     (!@ (from_voidp Entry.T.t buf))
-         | FUSE_OPENDIR     -> Opendir    (!@ (from_voidp Open.T.t buf))
-         | FUSE_READDIR     ->
+         | `FUSE_INIT        -> Init       (!@ (from_voidp Init.T.t buf))
+         | `FUSE_GETATTR     -> Getattr    (!@ (from_voidp Attr.T.t buf))
+         | `FUSE_LOOKUP      -> Lookup     (!@ (from_voidp Entry.T.t buf))
+         | `FUSE_OPENDIR     -> Opendir    (!@ (from_voidp Open.T.t buf))
+         | `FUSE_READDIR     ->
            Readdir (CArray.from_ptr (from_voidp char buf) len)
-         | FUSE_RELEASEDIR  -> Releasedir
-         | FUSE_FSYNCDIR    -> Fsyncdir
-         | FUSE_RMDIR       -> Rmdir
-         | FUSE_MKDIR       -> Mkdir      (!@ (from_voidp Entry.T.t buf))
-         | FUSE_GETXATTR    -> Getxattr
-         | FUSE_SETXATTR    -> Setxattr
-         | FUSE_LISTXATTR   -> Listxattr
-         | FUSE_REMOVEXATTR -> Removexattr
-         | FUSE_ACCESS      -> Access
-         | FUSE_FORGET      -> Forget
-         | FUSE_READLINK    -> Readlink   (coerce (ptr void) string buf)
-         | FUSE_OPEN        -> Open       (!@ (from_voidp Open.T.t buf))
-         | FUSE_READ        ->
+         | `FUSE_RELEASEDIR  -> Releasedir
+         | `FUSE_FSYNCDIR    -> Fsyncdir
+         | `FUSE_RMDIR       -> Rmdir
+         | `FUSE_MKDIR       -> Mkdir      (!@ (from_voidp Entry.T.t buf))
+         | `FUSE_GETXATTR    -> Getxattr
+         | `FUSE_SETXATTR    -> Setxattr
+         | `FUSE_LISTXATTR   -> Listxattr
+         | `FUSE_REMOVEXATTR -> Removexattr
+         | `FUSE_ACCESS      -> Access
+         | `FUSE_FORGET      -> Forget
+         | `FUSE_READLINK    -> Readlink   (coerce (ptr void) string buf)
+         | `FUSE_OPEN        -> Open       (!@ (from_voidp Open.T.t buf))
+         | `FUSE_READ        ->
            Read (CArray.from_ptr (from_voidp char buf) len)
-         | FUSE_WRITE       -> Write      (!@ (from_voidp Write.T.t buf))
-         | FUSE_STATFS      ->
+         | `FUSE_WRITE       -> Write      (!@ (from_voidp Write.T.t buf))
+         | `FUSE_STATFS      ->
            Statfs (!@ (from_voidp Struct.Kstatfs.T.t buf))
-         | FUSE_FLUSH       -> Flush
-         | FUSE_RELEASE     -> Release
-         | FUSE_FSYNC       -> Fsync
-         | FUSE_UNLINK      -> Unlink
-         | FUSE_CREATE      ->
+         | `FUSE_FLUSH       -> Flush
+         | `FUSE_RELEASE     -> Release
+         | `FUSE_FSYNC       -> Fsync
+         | `FUSE_UNLINK      -> Unlink
+         | `FUSE_CREATE      ->
            let entry = !@ (from_voidp Entry.T.t buf) in
            let ptr = (coerce (ptr void) (ptr char) buf) +@ Entry.sz in
            let open_ = !@ (from_voidp Open.T.t (to_voidp ptr)) in
            Create (entry, open_)
-         | FUSE_MKNOD       -> Mknod      (!@ (from_voidp Entry.T.t buf))
-         | FUSE_SETATTR     -> Setattr    (!@ (from_voidp Attr.T.t buf))
-         | FUSE_LINK        -> Link       (!@ (from_voidp Entry.T.t buf))
-         | FUSE_SYMLINK     -> Symlink    (!@ (from_voidp Entry.T.t buf))
-         | FUSE_RENAME      -> Rename
-         | FUSE_GETLK       -> Getlk
-         | FUSE_SETLK       -> Setlk
-         | FUSE_SETLKW      -> Setlkw
-         | FUSE_INTERRUPT   -> Interrupt
-         | FUSE_BMAP        -> Bmap
-         | FUSE_DESTROY     -> Destroy
+         | `FUSE_MKNOD       -> Mknod      (!@ (from_voidp Entry.T.t buf))
+         | `FUSE_SETATTR     -> Setattr    (!@ (from_voidp Attr.T.t buf))
+         | `FUSE_LINK        -> Link       (!@ (from_voidp Entry.T.t buf))
+         | `FUSE_SYMLINK     -> Symlink    (!@ (from_voidp Entry.T.t buf))
+         | `FUSE_RENAME      -> Rename
+         | `FUSE_GETLK       -> Getlk
+         | `FUSE_SETLK       -> Setlk
+         | `FUSE_SETLKW      -> Setlkw
+         | `FUSE_INTERRUPT   -> Interrupt
+         | `FUSE_BMAP        -> Bmap
+         | `FUSE_DESTROY     -> Destroy
          (*| FUSE_IOCTL
          | FUSE_POLL
          | FUSE_NOTIFY_REPLY
          | FUSE_BATCH_FORGET
          | FUSE_FALLOCATE
          | CUSE_INIT        -> Other opcode*)
-         | Unknown opcode   -> unknown opcode len buf
+         | `Unknown opcode   -> unknown opcode len buf
        )}
 
     let pnum = ref 0

--- a/lib/profuse.mli
+++ b/lib/profuse.mli
@@ -215,94 +215,94 @@ module Types : sig
 
   module In : sig
     module Opcode : sig
-      type t =
-        | FUSE_LOOKUP
-        | FUSE_FORGET
-        | FUSE_GETATTR
-        | FUSE_SETATTR
-        | FUSE_READLINK
-        | FUSE_SYMLINK
-        | FUSE_MKNOD
-        | FUSE_MKDIR
-        | FUSE_UNLINK
-        | FUSE_RMDIR
-        | FUSE_RENAME
-        | FUSE_LINK
-        | FUSE_OPEN
-        | FUSE_READ
-        | FUSE_WRITE
-        | FUSE_STATFS
-        | FUSE_RELEASE
-        | FUSE_FSYNC
-        | FUSE_SETXATTR
-        | FUSE_GETXATTR
-        | FUSE_LISTXATTR
-        | FUSE_REMOVEXATTR
-        | FUSE_FLUSH
-        | FUSE_INIT
-        | FUSE_OPENDIR
-        | FUSE_READDIR
-        | FUSE_RELEASEDIR
-        | FUSE_FSYNCDIR
-        | FUSE_GETLK
-        | FUSE_SETLK
-        | FUSE_SETLKW
-        | FUSE_ACCESS
-        | FUSE_CREATE
-        | FUSE_INTERRUPT
-        | FUSE_BMAP
-        | FUSE_DESTROY
+      type t = [
+        | `FUSE_LOOKUP
+        | `FUSE_FORGET
+        | `FUSE_GETATTR
+        | `FUSE_SETATTR
+        | `FUSE_READLINK
+        | `FUSE_SYMLINK
+        | `FUSE_MKNOD
+        | `FUSE_MKDIR
+        | `FUSE_UNLINK
+        | `FUSE_RMDIR
+        | `FUSE_RENAME
+        | `FUSE_LINK
+        | `FUSE_OPEN
+        | `FUSE_READ
+        | `FUSE_WRITE
+        | `FUSE_STATFS
+        | `FUSE_RELEASE
+        | `FUSE_FSYNC
+        | `FUSE_SETXATTR
+        | `FUSE_GETXATTR
+        | `FUSE_LISTXATTR
+        | `FUSE_REMOVEXATTR
+        | `FUSE_FLUSH
+        | `FUSE_INIT
+        | `FUSE_OPENDIR
+        | `FUSE_READDIR
+        | `FUSE_RELEASEDIR
+        | `FUSE_FSYNCDIR
+        | `FUSE_GETLK
+        | `FUSE_SETLK
+        | `FUSE_SETLKW
+        | `FUSE_ACCESS
+        | `FUSE_CREATE
+        | `FUSE_INTERRUPT
+        | `FUSE_BMAP
+        | `FUSE_DESTROY
         (*| FUSE_IOCTL
         | FUSE_POLL
         | FUSE_NOTIFY_REPLY
         | FUSE_BATCH_FORGET
         | FUSE_FALLOCATE
         | CUSE_INIT*)
-        | Unknown of int32
+        | `Unknown of int32
+      ]
 
-      val fuse_lookup : int64
-      val fuse_forget : int64
-      val fuse_getattr : int64
-      val fuse_setattr : int64
-      val fuse_readlink : int64
-      val fuse_symlink : int64
-      val fuse_mknod : int64
-      val fuse_mkdir : int64
-      val fuse_unlink : int64
-      val fuse_rmdir : int64
-      val fuse_rename : int64
-      val fuse_link : int64
-      val fuse_open : int64
-      val fuse_read : int64
-      val fuse_write : int64
-      val fuse_statfs : int64
-      val fuse_release : int64
-      val fuse_fsync : int64
-      val fuse_setxattr : int64
-      val fuse_getxattr : int64
-      val fuse_listxattr : int64
-      val fuse_removexattr : int64
-      val fuse_flush : int64
-      val fuse_init : int64
-      val fuse_opendir : int64
-      val fuse_readdir : int64
-      val fuse_releasedir : int64
-      val fuse_fsyncdir : int64
-      val fuse_getlk : int64
-      val fuse_setlk : int64
-      val fuse_setlkw : int64
-      val fuse_access : int64
-      val fuse_create : int64
-      val fuse_interrupt : int64
-      val fuse_bmap : int64
-      val fuse_destroy : int64
-      (*val fuse_ioctl : int64
-      val fuse_poll : int64
-      val fuse_notify_reply : int64
-      val fuse_batch_forget : int64
-      val fuse_fallocate : int64
-      val cuse_init : int64*)
-      val t : t Ctypes.typ
+      val fuse_lookup : Unsigned.uint32
+      val fuse_forget : Unsigned.uint32
+      val fuse_getattr : Unsigned.uint32
+      val fuse_setattr : Unsigned.uint32
+      val fuse_readlink : Unsigned.uint32
+      val fuse_symlink : Unsigned.uint32
+      val fuse_mknod : Unsigned.uint32
+      val fuse_mkdir : Unsigned.uint32
+      val fuse_unlink : Unsigned.uint32
+      val fuse_rmdir : Unsigned.uint32
+      val fuse_rename : Unsigned.uint32
+      val fuse_link : Unsigned.uint32
+      val fuse_open : Unsigned.uint32
+      val fuse_read : Unsigned.uint32
+      val fuse_write : Unsigned.uint32
+      val fuse_statfs : Unsigned.uint32
+      val fuse_release : Unsigned.uint32
+      val fuse_fsync : Unsigned.uint32
+      val fuse_setxattr : Unsigned.uint32
+      val fuse_getxattr : Unsigned.uint32
+      val fuse_listxattr : Unsigned.uint32
+      val fuse_removexattr : Unsigned.uint32
+      val fuse_flush : Unsigned.uint32
+      val fuse_init : Unsigned.uint32
+      val fuse_opendir : Unsigned.uint32
+      val fuse_readdir : Unsigned.uint32
+      val fuse_releasedir : Unsigned.uint32
+      val fuse_fsyncdir : Unsigned.uint32
+      val fuse_getlk : Unsigned.uint32
+      val fuse_setlk : Unsigned.uint32
+      val fuse_setlkw : Unsigned.uint32
+      val fuse_access : Unsigned.uint32
+      val fuse_create : Unsigned.uint32
+      val fuse_interrupt : Unsigned.uint32
+      val fuse_bmap : Unsigned.uint32
+      val fuse_destroy : Unsigned.uint32
+      (*val fuse_ioctl : Unsigned.uint32
+      val fuse_poll : Unsigned.uint32
+      val fuse_notify_reply : Unsigned.uint32
+      val fuse_batch_forget : Unsigned.uint32
+      val fuse_fallocate : Unsigned.uint32
+      val cuse_init : Unsigned.uint32*)
     end
 
     module Hdr : sig
@@ -310,7 +310,7 @@ module Types : sig
       val t : t structure Ctypes.typ
 
       val len : (Unsigned.uint32, t structure) Ctypes.field
-      val opcode : (Opcode.t, t structure) Ctypes.field
+      val opcode : (Unsigned.uint32, t structure) Ctypes.field
       val unique : (Unsigned.uint64, t structure) Ctypes.field
       val nodeid : (Unsigned.uint64, t structure) Ctypes.field
       val uid : (Unsigned.uint32, t structure) Ctypes.field
@@ -599,73 +599,7 @@ module In : sig
   module Opcode : sig
     module T = T.Opcode
 
-    type t = T.t =
-      (* ro *)
-      | FUSE_LOOKUP (* = 1 *)
-      | FUSE_FORGET (* no reply *)
-      | FUSE_GETATTR
-      (* end ro *)
-
-      | FUSE_SETATTR
-      | FUSE_READLINK
-      | FUSE_SYMLINK
-
-      | FUSE_MKNOD (* = 8 *)
-      | FUSE_MKDIR
-      | FUSE_UNLINK
-      | FUSE_RMDIR
-      | FUSE_RENAME
-      | FUSE_LINK
-
-      (* ro *)
-      | FUSE_OPEN (* = 14 *)
-      | FUSE_READ
-      (* end ro *)
-
-      | FUSE_WRITE
-      | FUSE_STATFS
-
-      (* ro *)
-      | FUSE_RELEASE (* = 18 *) (* 0 reply? *)
-      (* end ro *)
-
-      | FUSE_FSYNC (* = 20 *)
-      | FUSE_SETXATTR
-      | FUSE_GETXATTR
-      | FUSE_LISTXATTR
-      | FUSE_REMOVEXATTR
-      | FUSE_FLUSH (* 0 reply *)
-
-      (* ro *)
-      | FUSE_INIT (* = 26 *)
-      | FUSE_OPENDIR
-      | FUSE_READDIR
-      | FUSE_RELEASEDIR (* 0 reply *)
-      (* end ro *)
-
-      | FUSE_FSYNCDIR (* = 30 *)
-      | FUSE_GETLK
-      | FUSE_SETLK
-      | FUSE_SETLKW
-      | FUSE_ACCESS
-      | FUSE_CREATE
-      | FUSE_INTERRUPT
-      | FUSE_BMAP
-
-      (* ro *)
-      | FUSE_DESTROY (* = 38 *) (* no reply *)
-      (* end ro *)
-
-      (* > 7.8 *)
-      (*| FUSE_IOCTL
-      | FUSE_POLL
-      | FUSE_NOTIFY_REPLY
-      | FUSE_BATCH_FORGET
-      | FUSE_FALLOCATE
-
-      | CUSE_INIT*)
-
-      | Unknown of int32
+    type t = T.t
 
     val to_string : t -> string
 

--- a/lib_gen/profuse_types_7_11.ml
+++ b/lib_gen/profuse_types_7_11.ml
@@ -76,7 +76,28 @@ module C_compatible(F: Cstubs.Types.TYPE) = struct
 
   module In = struct
     module V_7_10 = Version_7_10.In
-    module Opcode = V_7_10.Opcode
+    module Opcode =
+    struct
+      include (V_7_10.Opcode
+               : module type of V_7_10.Opcode
+               with type t := V_7_10.Opcode.t)
+
+      let fuse_ioctl = constant "FUSE_IOCTL" uint32_t
+      let fuse_poll = constant "FUSE_POLL" uint32_t
+      let cuse_init = constant "CUSE_INIT" uint32_t
+
+      type t = [ V_7_10.Opcode.t
+               | `FUSE_IOCTL
+               | `FUSE_POLL
+               | `CUSE_INIT ]
+
+      let enum_values =
+        (`FUSE_IOCTL, fuse_ioctl) ::
+        (`FUSE_POLL, fuse_poll) ::
+        (`CUSE_INIT, cuse_init) ::
+        (V_7_10.Opcode.enum_values :> (t * _) list)
+    end
+
     module Hdr       = struct include V_7_10.Hdr       let () = seal t end
     module Init      = struct include V_7_10.Init      let () = seal t end
     module Release   = struct include V_7_10.Release   let () = seal t end
@@ -98,6 +119,13 @@ module C_compatible(F: Cstubs.Types.TYPE) = struct
     module Setattr   = struct include V_7_10.Setattr   let () = seal t end
     module Getattr   = struct include V_7_10.Getattr   let () = seal t end
     module Ioctl     = struct
+      module Flags =
+      struct
+        let t = uint32_t
+        let fuse_ioctl_compat = constant "FUSE_IOCTL_COMPAT" t
+        let fuse_ioctl_unrestricted = constant "FUSE_IOCTL_UNRESTRICTED" t
+        let fuse_ioctl_retry = constant "FUSE_IOCTL_RETRY" t
+      end
       type t
       let t : t structure typ = structure "fuse_ioctl_in"
       let ( -:* ) s x = field t s x
@@ -110,6 +138,11 @@ module C_compatible(F: Cstubs.Types.TYPE) = struct
       let () = seal t
     end
     module Poll      = struct
+      module Flags =
+      struct
+        let t = uint32_t
+        let fuse_poll_schedule_notify = constant "FUSE_POLL_SCHEDULE_NOTIFY" t
+      end
       type t
       let t : t structure typ = structure "fuse_poll_in"
       let ( -:* ) s x = field t s x

--- a/lib_gen/profuse_types_7_8.ml
+++ b/lib_gen/profuse_types_7_8.ml
@@ -193,51 +193,45 @@ module C_compatible(F: Cstubs.Types.TYPE) = struct
 
     module Opcode = struct
       type t =
-        | FUSE_LOOKUP
-        | FUSE_FORGET
-        | FUSE_GETATTR
-        | FUSE_SETATTR
-        | FUSE_READLINK
-        | FUSE_SYMLINK
-        | FUSE_MKNOD
-        | FUSE_MKDIR
-        | FUSE_UNLINK
-        | FUSE_RMDIR
-        | FUSE_RENAME
-        | FUSE_LINK
-        | FUSE_OPEN
-        | FUSE_READ
-        | FUSE_WRITE
-        | FUSE_STATFS
-        | FUSE_RELEASE
-        | FUSE_FSYNC
-        | FUSE_SETXATTR
-        | FUSE_GETXATTR
-        | FUSE_LISTXATTR
-        | FUSE_REMOVEXATTR
-        | FUSE_FLUSH
-        | FUSE_INIT
-        | FUSE_OPENDIR
-        | FUSE_READDIR
-        | FUSE_RELEASEDIR
-        | FUSE_FSYNCDIR
-        | FUSE_GETLK
-        | FUSE_SETLK
-        | FUSE_SETLKW
-        | FUSE_ACCESS
-        | FUSE_CREATE
-        | FUSE_INTERRUPT
-        | FUSE_BMAP
-        | FUSE_DESTROY
-        (*| FUSE_IOCTL (* not 7.8 *)
-        | FUSE_POLL
-        | FUSE_NOTIFY_REPLY
-        | FUSE_BATCH_FORGET
-        | FUSE_FALLOCATE
-          | CUSE_INIT*)
-        | Unknown of int32
+        [ `FUSE_LOOKUP
+        | `FUSE_FORGET
+        | `FUSE_GETATTR
+        | `FUSE_SETATTR
+        | `FUSE_READLINK
+        | `FUSE_SYMLINK
+        | `FUSE_MKNOD
+        | `FUSE_MKDIR
+        | `FUSE_UNLINK
+        | `FUSE_RMDIR
+        | `FUSE_RENAME
+        | `FUSE_LINK
+        | `FUSE_OPEN
+        | `FUSE_READ
+        | `FUSE_WRITE
+        | `FUSE_STATFS
+        | `FUSE_RELEASE
+        | `FUSE_FSYNC
+        | `FUSE_SETXATTR
+        | `FUSE_GETXATTR
+        | `FUSE_LISTXATTR
+        | `FUSE_REMOVEXATTR
+        | `FUSE_FLUSH
+        | `FUSE_INIT
+        | `FUSE_OPENDIR
+        | `FUSE_READDIR
+        | `FUSE_RELEASEDIR
+        | `FUSE_FSYNCDIR
+        | `FUSE_GETLK
+        | `FUSE_SETLK
+        | `FUSE_SETLKW
+        | `FUSE_ACCESS
+        | `FUSE_CREATE
+        | `FUSE_INTERRUPT
+        | `FUSE_BMAP
+        | `FUSE_DESTROY
+        | `Unknown of int32 ]
 
-      let t = int64_t
+      let t = uint32_t
 
       let fuse_lookup = constant "FUSE_LOOKUP" t
       let fuse_forget = constant "FUSE_FORGET" t
@@ -275,60 +269,45 @@ module C_compatible(F: Cstubs.Types.TYPE) = struct
       let fuse_interrupt = constant "FUSE_INTERRUPT" t
       let fuse_bmap = constant "FUSE_BMAP" t
       let fuse_destroy = constant "FUSE_DESTROY" t
-      (*let fuse_ioctl = constant "FUSE_IOCTL" t
-      let fuse_poll = constant "FUSE_POLL" t
-      let fuse_notify_reply = constant "FUSE_NOTIFY_REPLY" t
-      let fuse_batch_forget = constant "FUSE_BATCH_FORGET" t
-      let fuse_fallocate = constant "FUSE_FALLOCATE" t
-        let cuse_init = constant "CUSE_INIT" t*)
 
-      let t =
-        enum "fuse_opcode"
-          ~unexpected:(fun code -> Unknown (Int64.to_int32 code))
-          [
-            FUSE_LOOKUP, fuse_lookup;
-            FUSE_FORGET, fuse_forget;
-            FUSE_GETATTR, fuse_getattr;
-            FUSE_SETATTR, fuse_setattr;
-            FUSE_READLINK, fuse_readlink;
-            FUSE_SYMLINK, fuse_symlink;
-            FUSE_MKNOD, fuse_mknod;
-            FUSE_MKDIR, fuse_mkdir;
-            FUSE_UNLINK, fuse_unlink;
-            FUSE_RMDIR, fuse_rmdir;
-            FUSE_RENAME, fuse_rename;
-            FUSE_LINK, fuse_link;
-            FUSE_OPEN, fuse_open;
-            FUSE_READ, fuse_read;
-            FUSE_WRITE, fuse_write;
-            FUSE_STATFS, fuse_statfs;
-            FUSE_RELEASE, fuse_release;
-            FUSE_FSYNC, fuse_fsync;
-            FUSE_SETXATTR, fuse_setxattr;
-            FUSE_GETXATTR, fuse_getxattr;
-            FUSE_LISTXATTR, fuse_listxattr;
-            FUSE_REMOVEXATTR, fuse_removexattr;
-            FUSE_FLUSH, fuse_flush;
-            FUSE_INIT, fuse_init;
-            FUSE_OPENDIR, fuse_opendir;
-            FUSE_READDIR, fuse_readdir;
-            FUSE_RELEASEDIR, fuse_releasedir;
-            FUSE_FSYNCDIR, fuse_fsyncdir;
-            FUSE_GETLK, fuse_getlk;
-            FUSE_SETLK, fuse_setlk;
-            FUSE_SETLKW, fuse_setlkw;
-            FUSE_ACCESS, fuse_access;
-            FUSE_CREATE, fuse_create;
-            FUSE_INTERRUPT, fuse_interrupt;
-            FUSE_BMAP, fuse_bmap;
-            FUSE_DESTROY, fuse_destroy;
-            (*FUSE_IOCTL, fuse_ioctl;
-            FUSE_POLL, fuse_poll;
-            FUSE_NOTIFY_REPLY, fuse_notify_reply;
-            FUSE_BATCH_FORGET, fuse_batch_forget;
-            FUSE_FALLOCATE, fuse_fallocate;
-              CUSE_INIT, cuse_init;*)
-          ]
+      let enum_values : (t * _) list = 
+        [ `FUSE_LOOKUP, fuse_lookup;
+          `FUSE_FORGET, fuse_forget;
+          `FUSE_GETATTR, fuse_getattr;
+          `FUSE_SETATTR, fuse_setattr;
+          `FUSE_READLINK, fuse_readlink;
+          `FUSE_SYMLINK, fuse_symlink;
+          `FUSE_MKNOD, fuse_mknod;
+          `FUSE_MKDIR, fuse_mkdir;
+          `FUSE_UNLINK, fuse_unlink;
+          `FUSE_RMDIR, fuse_rmdir;
+          `FUSE_RENAME, fuse_rename;
+          `FUSE_LINK, fuse_link;
+          `FUSE_OPEN, fuse_open;
+          `FUSE_READ, fuse_read;
+          `FUSE_WRITE, fuse_write;
+          `FUSE_STATFS, fuse_statfs;
+          `FUSE_RELEASE, fuse_release;
+          `FUSE_FSYNC, fuse_fsync;
+          `FUSE_SETXATTR, fuse_setxattr;
+          `FUSE_GETXATTR, fuse_getxattr;
+          `FUSE_LISTXATTR, fuse_listxattr;
+          `FUSE_REMOVEXATTR, fuse_removexattr;
+          `FUSE_FLUSH, fuse_flush;
+          `FUSE_INIT, fuse_init;
+          `FUSE_OPENDIR, fuse_opendir;
+          `FUSE_READDIR, fuse_readdir;
+          `FUSE_RELEASEDIR, fuse_releasedir;
+          `FUSE_FSYNCDIR, fuse_fsyncdir;
+          `FUSE_GETLK, fuse_getlk;
+          `FUSE_SETLK, fuse_setlk;
+          `FUSE_SETLKW, fuse_setlkw;
+          `FUSE_ACCESS, fuse_access;
+          `FUSE_CREATE, fuse_create;
+          `FUSE_INTERRUPT, fuse_interrupt;
+          `FUSE_BMAP, fuse_bmap;
+          `FUSE_DESTROY, fuse_destroy;
+        ]
     end
 
     module Hdr = struct
@@ -336,7 +315,7 @@ module C_compatible(F: Cstubs.Types.TYPE) = struct
       let t : t structure typ = structure "fuse_in_header"
       let ( -:* ) s x = field t s x
       let len     = "len"     -:* uint32_t
-      let opcode  = "opcode"  -:* Opcode.t
+      let opcode  = "opcode"  -:* uint32_t
       let unique  = "unique"  -:* uint64_t
       let nodeid  = "nodeid"  -:* uint64_t
       let uid     = "uid"     -:* uint32_t

--- a/lib_gen/profuse_types_7_8.ml
+++ b/lib_gen/profuse_types_7_8.ml
@@ -346,6 +346,12 @@ module C_compatible(F: Cstubs.Types.TYPE) = struct
     end
 
     module Init = struct
+      module Flags =
+      struct
+        let t = uint32_t
+        let async_read = constant "FUSE_ASYNC_READ" t
+        let posix_locks = constant "FUSE_POSIX_LOCKS" t
+      end
       type t
       let t : t structure typ = structure "fuse_init_in"
       let ( -:* ) s x = field t s x

--- a/lib_gen/profuse_types_7_9.ml
+++ b/lib_gen/profuse_types_7_9.ml
@@ -58,7 +58,6 @@ module C_compatible(F: Cstubs.Types.TYPE) = struct
     module V_7_8 = Version_7_8.In
     module Opcode = V_7_8.Opcode
     module Hdr       = struct include V_7_8.Hdr       let () = seal t end
-    module Init      = struct include V_7_8.Init      let () = seal t end
     module Release   = struct include V_7_8.Release   let () = seal t end
     module Access    = struct include V_7_8.Access    let () = seal t end
     module Forget    = struct include V_7_8.Forget    let () = seal t end
@@ -72,7 +71,24 @@ module C_compatible(F: Cstubs.Types.TYPE) = struct
     module Bmap      = struct include V_7_8.Bmap      let () = seal t end
     module Getxattr  = struct include V_7_8.Getxattr  let () = seal t end
     module Setxattr  = struct include V_7_8.Setxattr  let () = seal t end
+    module Init      = struct
+      module Flags =
+      struct
+        include V_7_8.Init.Flags
+        let fuse_file_ops = constant "FUSE_FILE_OPS" t
+        let fuse_atomic_o_trunc = constant "FUSE_ATOMIC_O_TRUNC" t
+        let fuse_big_writes = constant "FUSE_BIG_WRITES" t
+      end
+      include (V_7_8.Init
+               : module type of V_7_8.Init with module Flags := Flags)
+      let () = seal t
+    end
     module Read      = struct
+      module Flags =
+      struct
+        let t = uint32_t
+        let fuse_read_lockowner = constant "FUSE_READ_LOCKOWNER" t
+      end
       include V_7_8.Read
       let read_flags = "read_flags" -:* uint32_t
       let lock_owner = "lock_owner" -:* uint64_t
@@ -80,22 +96,46 @@ module C_compatible(F: Cstubs.Types.TYPE) = struct
       let () = seal t
     end
     module Write     = struct
+      module Flags =
+      struct
+        let t = uint32_t
+        let fuse_write_cache = constant "FUSE_WRITE_CACHE" t
+        let fuse_write_lockowner = constant "FUSE_WRITE_LOCKOWNER" t
+      end
       include V_7_8.Write
       let lock_owner = "lock_owner" -:* uint64_t
       let flags      = "flags"      -:* uint32_t
       let () = seal t
     end
     module Lk        = struct
+      module Flags =
+      struct
+        let t = uint32_t
+        let fuse_lk_flock = constant "FUSE_LK_FLOCK" t
+      end
       include V_7_8.Lk
       let lk_flags   = "lk_flags"   -:* uint32_t
       let () = seal t
     end
     module Setattr   = struct
-      include V_7_8.Setattr
+      module Valid =
+      struct
+        include V_7_8.Setattr.Valid
+        let fattr_atime_now = constant "FATTR_ATIME_NOW" t
+        let fattr_mtime_now = constant "FATTR_MTIME_NOW" t
+        let fattr_lockowner = constant "FATTR_LOCKOWNER" t
+      end
+      include (V_7_8.Setattr
+               : module type of V_7_8.Setattr with module Valid := Valid)
       let lock_owner     = "lock_owner" -:* uint64_t
       let () = seal t
     end
     module Getattr   = struct
+      module Flags =
+      struct
+        let t = uint32_t
+        let fuse_getattr_fh = constant "FUSE_GETATTR_FH" t
+      end
       type t
       let t : t structure typ = structure "fuse_getattr_in"
       let ( -:* ) s x = field t s x

--- a/lwt/fuse_lwt.ml
+++ b/lwt/fuse_lwt.ml
@@ -144,7 +144,7 @@ module IO : IO_LWT = struct
             (* assumes sequentially increasing packet ids *)
             let unique = UInt64.succ chan.Profuse.unique in
             chan.Profuse.unique <- unique;
-            let pkt = Hdr.packet ~opcode:Opcode.FUSE_DESTROY ~unique
+            let pkt = Hdr.packet ~opcode:`FUSE_DESTROY ~unique
                 ~nodeid ~uid ~gid ~pid ~count:0
             in
             let hdr = !@ (coerce (ptr char) (ptr Hdr.T.t)


### PR DESCRIPTION
There are a few interface-breaking changes:
- `Profuse.In.Opcode.t` (and `Profuse.Types.In.Opcode.t`)  is now a polymorphic variant type, which is extended with new labels in the bindings for FUSE 7.11
- The `fuse_*` flags in `Profuse.In.Opcode` (i.e. `fuse_lookup`, `fuse_forget`, etc.) now have type `uint32`rather than `int64`
- The `opcode` field of the `Profuse.In.Hdr.t` structure now has type `uint32`, not `Opcode.t`
