### PR TITLE
Fix a build system issue and work-around ocaml/ocamlbuild#42

### DIFF
--- a/META
+++ b/META
@@ -1,11 +1,11 @@
-version = "0.3.0"
+version = "0.4.0"
 description = "Linux FUSE protocol 7.8 bindings"
 requires = "ctypes.stubs unix-sys-stat.unix unix-errno unix-dirent.unix unix-fcntl unix-unistd"
-archive(byte) = "profuse.cma"
-archive(byte, plugin) = "profuse.cma"
-archive(native) = "profuse.cmxa"
-archive(native, plugin) = "profuse.cmxs"
-exists_if = "profuse.cma"
+archive(byte) = "profuse_.cma"
+archive(byte, plugin) = "profuse_.cma"
+archive(native) = "profuse_.cmxa"
+archive(native, plugin) = "profuse_.cmxs"
+exists_if = "profuse_.cma"
 
 package "lwt" (
   requires = "profuse lwt.unix unix-errno.unix"

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ WITH_CMDLINER=$(shell ocamlfind query cmdliner > /dev/null 2>&1 ; echo $$?)
 
 TARGETS=.cma .cmxa
 
-PRODUCTS=$(addprefix $(MOD_NAME),$(TARGETS)) \
+PRODUCTS=$(addprefix $(MOD_NAME)_,$(TARGETS)) \
 
 #         $(addprefix $(MOD_NAME)_linux,$(TARGETS))
 #	lib$(MOD_NAME)_stubs.a dll$(MOD_NAME)_stubs.so
@@ -35,7 +35,7 @@ INSTALL:=$(addprefix $(MOD_NAME), $(TYPES)) \
          $(addprefix fuse, $(TYPES)) \
          $(addprefix handles, $(TYPES)) \
          $(addprefix nodes, $(TYPES)) \
-         $(addprefix $(MOD_NAME), $(TARGETS))
+         $(addprefix $(MOD_NAME)_, $(TARGETS))
 
 INSTALL:=$(addprefix _build/lib/,$(INSTALL))
 
@@ -48,7 +48,7 @@ INSTALL_LWT:=$(addprefix _build/lwt/,$(INSTALL_LWT))
 INSTALL+=$(INSTALL_LWT)
 endif
 
-ARCHIVES:=_build/lib/$(MOD_NAME).a
+ARCHIVES:=_build/lib/$(MOD_NAME)_.a
 
 ifeq ($(WITH_LWT), 0)
 ARCHIVES+=_build/lwt/$(MOD_NAME)_lwt.a

--- a/lib/_tags
+++ b/lib/_tags
@@ -1,2 +1,2 @@
-<*.*>: package(ctypes.stubs), package(unix-errno), package(unix-dirent.unix), package(unix-sys-stat.unix), package(unix-fcntl), package(unix-unistd)
+<*.*>: package(ctypes.stubs), package(unix-errno), package(unix-dirent.unix), package(unix-sys-stat.unix), package(unix-fcntl), package(unix-unistd.unix)
 true: debug

--- a/lib/profuse_.mllib
+++ b/lib/profuse_.mllib
@@ -18,4 +18,3 @@ Profuse_types_detected_7_20
 Profuse_types_detected_7_21
 Profuse_types_detected_7_22
 Profuse_types_detected_7_23
-Profuse_types


### PR DESCRIPTION
It's crazy that the previous issue was masked due to ocaml/ocamlbuild#42.
