### PR TITLE
Describe GETATTR and SETATTR

### DIFF
--- a/lib/profuse_7_23.ml
+++ b/lib/profuse_7_23.ml
@@ -1133,6 +1133,13 @@ module Out = struct
       setf pkt T.attr_valid_nsec attr_valid_nsec;
       store_attr (getf pkt T.attr);
       CArray.from_ptr (coerce (ptr T.t) (ptr char) (addr pkt)) (sizeof T.t)
+
+    let describe ~host pkt =
+      Printf.sprintf
+        "attr_valid=%Ld.%ld attr={%s}"
+        (Unsigned.UInt64.to_int64 (getf pkt T.attr_valid))
+        (Unsigned.UInt32.to_int32 (getf pkt T.attr_valid_nsec))
+        (Struct.Attr.describe ~host (getf pkt T.attr))
   end
 
   module Create = struct
@@ -1286,7 +1293,7 @@ module Out = struct
       let host = chan.host in
       match pkt with
       | Init i -> Init.describe i
-      | Getattr a -> "GETATTR FIXME" (* TODO: more *)
+      | Getattr a -> Attr.describe ~host a
       | Lookup e -> Entry.describe ~host e
       | Opendir o -> "OPENDIR FIXME" (* TODO: more *)
       | Readdir r -> Dirent.describe ~host r
@@ -1313,7 +1320,7 @@ module Out = struct
         Printf.sprintf "[%s][%s]"
           (Entry.describe ~host entry) (Open.describe open_)
       | Mknod e -> Entry.describe ~host e
-      | Setattr a -> "SETATTR FIXME" (* TODO: more *)
+      | Setattr a -> Attr.describe ~host a
       | Link e -> Entry.describe ~host e
       | Symlink e -> Entry.describe ~host e
       | Rename -> "RENAME"

--- a/lib/profuse_7_23.mli
+++ b/lib/profuse_7_23.mli
@@ -805,7 +805,7 @@ module In : sig
         unknown : int32;
         atime_now : bool;
         mtime_now : bool;
-        lockowner : bool;
+        lock_owner : bool;
         ctime : bool;
       }
 
@@ -827,7 +827,7 @@ module In : sig
       mode:Unsigned.uint32 ->
       uid:Unsigned.uint32 ->
       gid:Unsigned.uint32 ->
-      lockowner:Unsigned.uint64 ->
+      lock_owner:Unsigned.uint64 ->
       ctime:Unsigned.uint64 ->
       ctimensec:Unsigned.uint32 ->
       Hdr.T.t structure -> char Ctypes.CArray.t

--- a/lib/profuse_7_8.ml
+++ b/lib/profuse_7_8.ml
@@ -981,6 +981,13 @@ module Out = struct
       setf pkt T.attr_valid_nsec attr_valid_nsec;
       store_attr (getf pkt T.attr);
       CArray.from_ptr (coerce (ptr T.t) (ptr char) (addr pkt)) (sizeof T.t)
+
+    let describe ~host pkt =
+      Printf.sprintf
+        "attr_valid=%Ld.%ld attr={%s}"
+        (Unsigned.UInt64.to_int64 (getf pkt T.attr_valid))
+        (Unsigned.UInt32.to_int32 (getf pkt T.attr_valid_nsec))
+        (Struct.Attr.describe ~host (getf pkt T.attr))
   end
 
   module Create = struct
@@ -1130,7 +1137,7 @@ module Out = struct
       let host = chan.host in
       match pkt with
       | Init i -> Init.describe i
-      | Getattr a -> "GETATTR FIXME" (* TODO: more *)
+      | Getattr a -> Attr.describe ~host a
       | Lookup e -> Entry.describe ~host e
       | Opendir o -> "OPENDIR FIXME" (* TODO: more *)
       | Readdir r -> Dirent.describe ~host r
@@ -1157,7 +1164,7 @@ module Out = struct
         Printf.sprintf "[%s][%s]"
           (Entry.describe ~host entry) (Open.describe open_)
       | Mknod e -> Entry.describe ~host e
-      | Setattr a -> "SETATTR FIXME" (* TODO: more *)
+      | Setattr a -> Attr.describe ~host a
       | Link e -> Entry.describe ~host e
       | Symlink e -> Entry.describe ~host e
       | Rename -> "RENAME"


### PR DESCRIPTION
- Add describe for `GETATTR` and `SETATTR` response
- Add `Setattr.to_string_list` for `SETATTR` values in descriptions
- Also, rename `Profuse_7_23.Setattr.Valid.lockowner` field to `lock_owner` and `Profuse_7_23.Setattr.create_from_hdr` `lockowner` argument to `lock_owner` to match the FUSE names.
