### PR TITLE
Fix a non-empty directory node renaming bug

### DIFF
--- a/lib/nodes.mli
+++ b/lib/nodes.mli
@@ -33,7 +33,7 @@ module type NODE = sig
 
   val to_string : t -> string
   val child : t node -> string -> t
-  val rename : t node -> t node -> string -> t node
+  val rename : t node -> t node -> string -> unit
 end
 
 module Path : NODE with type t = string list


### PR DESCRIPTION
Not rewriting the data of descendent nodes causes stale data to confuse the file system server.
