### PR TITLE
Fix node reuse pitfalls

### DIFF
--- a/lib/nodes.ml
+++ b/lib/nodes.ml
@@ -199,15 +199,16 @@ module Make(N : NODE) = struct
         failwith (Printf.sprintf "set: fh %Ld missing from %s"
                     fh (to_string space))
 
-    let open_ node kind =
-      let { space } = node in
+    let open_ space id kind =
+      let { table; handles } = space in
       let fh = match space.freeh with
         | fh::r -> space.freeh <- r; fh
         | [] -> let fh = space.maxh in space.maxh <- Int64.add fh 1L; fh
       in
+      let node = Hashtbl.find table id in
       let node = { node with data = N.set_handle node fh kind } in
-      Hashtbl.replace space.table node.id node;
-      Hashtbl.replace space.handles fh node.id;
+      Hashtbl.replace table id node;
+      Hashtbl.replace handles fh id;
       fh
 
     let free space fh =

--- a/lib/nodes.ml
+++ b/lib/nodes.ml
@@ -301,15 +301,15 @@ module Make(N : NODE) = struct
     unlink srcpn dest;
     N.rename destpn srcn dest
 
-  let forget node n =
-    let { space } = node in
+  let forget space id n =
     let { table } = space in
+    let node = Hashtbl.find table id in
     let lookups = node.lookups - n in
     if lookups > 0
-    then Hashtbl.replace table node.id { node with lookups }
+    then Hashtbl.replace table id { node with lookups }
     else begin
-      Hashtbl.remove table node.id;
-      space.free <- (Int64.add node.gen 1L, node.id)::space.free;
+      Hashtbl.remove table id;
+      space.free <- (Int64.add node.gen 1L, id)::space.free;
       match node.parent with
       | None -> ()
       | Some parent ->

--- a/lib/nodes.mli
+++ b/lib/nodes.mli
@@ -66,7 +66,7 @@ module Make(N : NODE) : sig
   val to_string    : t -> string
 
   module Handle : sig
-    val open_ : N.t node -> N.h -> fh
+    val open_ : N.t space -> id -> N.h -> fh
     val get   : t -> fh -> N.h
     val set   : t -> fh -> N.h -> unit
     val free  : t -> fh -> unit

--- a/lib/nodes.mli
+++ b/lib/nodes.mli
@@ -76,5 +76,5 @@ module Make(N : NODE) : sig
   val handles : N.t node -> (fh * N.h) list
   val rename : N.t node -> string -> N.t node -> string -> unit
   val unlink : N.t node -> string -> unit
-  val forget : N.t node -> int -> unit
+  val forget : N.t space -> id -> int -> unit
 end


### PR DESCRIPTION
`Nodes.Handle.open_` and `Nodes.forget` used to take a node as an argument and use it as the basis for modified node data. If the user provides an out-of-date node, perhaps due to subsequent (parallel) table modifications between querying and invoking `Handle.open_` or `forget`, old node data could be reloaded leading to node table corruption.

This change protects node table invariants by ensuring that user-provided nodes are not trusted except for identifiers and mutable references.
