### PR TITLE
Nodes.rename insanely unlinked a totally unrelated path

### DIFF
--- a/lib/nodes.ml
+++ b/lib/nodes.ml
@@ -298,7 +298,7 @@ module Make(N : NODE) = struct
              (string_of_id space srcpn.id) src id)
     in
     Hashtbl.remove srcpn.children src;
-    unlink srcpn dest;
+    unlink destpn dest;
     N.rename destpn srcn dest
 
   let forget space id n =


### PR DESCRIPTION
This causes havoc and is surprisingly blatant. I should probably retire.

Thanks to @tomjridge and @yallop for helping me find the bug during a module overview discussion.
