### PR TITLE
Extend 'describe' with support for more messages

### DIFF
--- a/lib/fuse.ml
+++ b/lib/fuse.ml
@@ -72,7 +72,7 @@ end
 module type RO_FULL = sig
   include RO_MID
 
-  val getxattr  : In.Getxattr.T.t structure -> t req_handler
+  val getxattr  : In.Getxattr.T.t structure -> string -> t req_handler
   val listxattr : In.Getxattr.T.t structure -> t req_handler
   val interrupt : In.Interrupt.T.t structure -> t req_handler
   val bmap      : In.Bmap.T.t structure -> t req_handler
@@ -112,7 +112,7 @@ module type RW_FULL = sig
      and type 'a req_handler := 'a req_handler
 
   val fsyncdir    : In.Fsync.T.t structure -> t req_handler
-  val setxattr    : In.Setxattr.T.t structure -> t req_handler
+  val setxattr    : In.Setxattr.T.t structure -> string -> t req_handler
   val removexattr : string -> t req_handler
   val getlk       : In.Lk.T.t structure -> t req_handler (* TODO: RO? *)
   val setlk       : In.Lk.T.t structure -> t req_handler (* TODO: RO? *)
@@ -168,7 +168,7 @@ module Zero(State : STATE)(IO : IO)
   let destroy      = enosys
 
   let statfs       = enosys
-  let getxattr _   = enosys
+  let getxattr _ _ = enosys
   let listxattr _  = enosys
   let interrupt _  = enosys
   let bmap _       = enosys
@@ -187,7 +187,7 @@ module Zero(State : STATE)(IO : IO)
   let create _ _   = enosys
   let fsync _      = enosys
   let fsyncdir _   = enosys
-  let setxattr _   = enosys
+  let setxattr _ _ = enosys
   let removexattr _= enosys
   let getlk _      = enosys
   let setlk _      = enosys

--- a/lib/fuse.mli
+++ b/lib/fuse.mli
@@ -57,7 +57,7 @@ end
 module type RO_FULL = sig
   include RO_MID
 
-  val getxattr : Profuse.In.Getxattr.T.t structure -> t req_handler
+  val getxattr : Profuse.In.Getxattr.T.t structure -> string -> t req_handler
   val listxattr : Profuse.In.Getxattr.T.t structure -> t req_handler
   val interrupt : Profuse.In.Interrupt.T.t structure -> t req_handler
   val bmap : Profuse.In.Bmap.T.t structure -> t req_handler
@@ -99,7 +99,7 @@ module type RW_FULL = sig
      and type 'a req_handler := 'a req_handler
 
   val fsyncdir    : Profuse.In.Fsync.T.t structure -> t req_handler
-  val setxattr    : Profuse.In.Setxattr.T.t structure -> t req_handler
+  val setxattr    : Profuse.In.Setxattr.T.t structure -> string -> t req_handler
   val removexattr : string -> t req_handler
   val getlk       : Profuse.In.Lk.T.t structure -> t req_handler
   val setlk       : Profuse.In.Lk.T.t structure -> t req_handler

--- a/lib/profuse_7_23.ml
+++ b/lib/profuse_7_23.ml
@@ -615,6 +615,8 @@ module In = struct
       let pkt = Hdr.make_from_hdr hdr T.t in
       setf pkt T.size size;
       CArray.from_ptr (coerce (ptr T.t) (ptr char) (addr pkt)) (sizeof T.t)
+
+    let name p = coerce (ptr char) string (from_voidp char p +@ sizeof T.t)
   end
 
   module Setxattr = struct
@@ -625,6 +627,8 @@ module In = struct
       setf pkt T.size  size;
       setf pkt T.flags flags;
       CArray.from_ptr (coerce (ptr T.t) (ptr char) (addr pkt)) (sizeof T.t)
+
+    let name p = coerce (ptr char) string (from_voidp char p +@ sizeof T.t)
   end
 
   module Batch_forget = struct
@@ -641,8 +645,8 @@ module In = struct
       | Releasedir of Release.T.t structure
       | Fsyncdir of Fsync.T.t structure
       | Rmdir of string
-      | Getxattr of Getxattr.T.t structure
-      | Setxattr of Setxattr.T.t structure
+      | Getxattr of Getxattr.T.t structure * string
+      | Setxattr of Setxattr.T.t structure * string
       | Listxattr of Getxattr.T.t structure
       | Removexattr of string
       | Access of Access.T.t structure
@@ -690,8 +694,14 @@ module In = struct
            let name = Mkdir.name buf in
            let s = !@ (from_voidp Mkdir.T.t buf) in
            Mkdir (s, name)
-         | `FUSE_GETXATTR    -> Getxattr   (!@ (from_voidp Getxattr.T.t buf))
-         | `FUSE_SETXATTR    -> Setxattr   (!@ (from_voidp Setxattr.T.t buf))
+         | `FUSE_GETXATTR    ->
+            let name = Getxattr.name buf in
+            let s = !@ (from_voidp Getxattr.T.t buf) in
+            Getxattr (s, name)
+         | `FUSE_SETXATTR    ->
+            let name = Setxattr.name buf in
+            let s = !@ (from_voidp Setxattr.T.t buf) in
+            Setxattr (s, name)
          | `FUSE_LISTXATTR   -> Listxattr  (!@ (from_voidp Getxattr.T.t buf))
          | `FUSE_REMOVEXATTR -> Removexattr (coerce (ptr void) string buf)
          | `FUSE_ACCESS      -> Access     (!@ (from_voidp Access.T.t buf))
@@ -892,14 +902,16 @@ module In = struct
              (UInt32.to_string flags)
              (UInt32.to_string rflags)
              (UInt64.to_string lock_owner)
-         | Getxattr r ->
+         | Getxattr (r, name) ->
            let size = getf r Getxattr.T.size in
-           Printf.sprintf "size=%ld"
+           Printf.sprintf "name=%s size=%ld"
+             name
              (UInt32.to_int32 size)
-         | Setxattr r ->
+         | Setxattr (r, name) ->
            let size = getf r Setxattr.T.size in
            let flags = getf r Setxattr.T.flags in
-           Printf.sprintf "size=%ld flags%ld="
+           Printf.sprintf "name=%s size=%ld flags%ld="
+             name
              (UInt32.to_int32 size)
              (UInt32.to_int32 flags)
          | Listxattr r ->

--- a/lib/profuse_7_23.ml
+++ b/lib/profuse_7_23.ml
@@ -929,10 +929,10 @@ module In = struct
            Printf.sprintf "oldnodeid=%s %s"
              (UInt64.to_string (getf l Link.T.oldnodeid))
              n
-         | Flush _r -> ""
-         | Fsyncdir _r -> ""
-         | Fsync _r -> ""
-         | Bmap _r -> ""
+         | Flush _r -> "FIXME"
+         | Fsyncdir _r -> "FIXME"
+         | Fsync _r -> "FIXME"
+         | Bmap _r -> "FIXME"
          | Batch_forget b ->
            let forgets = String.concat ", " (List.map (fun forget ->
              let id = getf forget Struct.Forget_one.T.nodeid in

--- a/lib/profuse_7_23.ml
+++ b/lib/profuse_7_23.ml
@@ -394,10 +394,12 @@ module In = struct
     let describe lk =
       let fh = getf lk T.fh
       and owner = getf lk T.owner
-      and lk = getf lk T.lk in
-      Printf.sprintf "fh=%Ld owner=%Ld lk=(%s)"
+      and lk = getf lk T.lk
+      and lk_flags = getf lk T.lk_flags in
+      Printf.sprintf "fh=%Ld owner=%Ld lk=(%s) lk_flags=%Ld"
         fh (UInt64.to_int64 owner)
         (Struct.File_lock.describe lk)
+	(UInt32.to_int64 lk_flags)
   end
 
   module Interrupt = struct
@@ -910,7 +912,7 @@ module In = struct
          | Setxattr (r, name) ->
            let size = getf r Setxattr.T.size in
            let flags = getf r Setxattr.T.flags in
-           Printf.sprintf "name=%s size=%ld flags%ld="
+           Printf.sprintf "name=%s size=%ld flags=%ld"
              name
              (UInt32.to_int32 size)
              (UInt32.to_int32 flags)

--- a/lib/profuse_7_23.ml
+++ b/lib/profuse_7_23.ml
@@ -926,8 +926,9 @@ module In = struct
          | Setlkw t ->
            Lk.describe t
          | Link (l,n) ->
-           let name = Link.name (to_voidp (addr l)) in
-           Printf.sprintf "name=%s %s" name n
+           Printf.sprintf "oldnodeid=%s %s"
+             (UInt64.to_string (getf l Link.T.oldnodeid))
+             n
          | Flush _r -> ""
          | Fsyncdir _r -> ""
          | Fsync _r -> ""

--- a/lib/profuse_7_23.ml
+++ b/lib/profuse_7_23.ml
@@ -115,6 +115,17 @@ module Struct = struct
 
   module File_lock = struct
     module T = T.File_lock
+
+    let describe fl =
+      let start = getf fl T.start
+      and end_ = getf fl T.end_
+      and type_ = getf fl T.type_
+      and pid = getf fl T.pid in
+      Printf.sprintf "start=%Ld end=%Ld type=%ld pid=%ld"
+        (UInt64.to_int64 start)
+        (UInt64.to_int64 end_)
+        (UInt32.to_int32 type_)
+        (UInt32.to_int32 pid)
   end
 
   module Attr = struct
@@ -379,6 +390,14 @@ module In = struct
 
   module Lk = struct
     module T = T.Lk
+
+    let describe lk =
+      let fh = getf lk T.fh
+      and owner = getf lk T.owner
+      and lk = getf lk T.lk in
+      Printf.sprintf "fh=%Ld owner=%Ld lk=(%s)"
+        fh (UInt64.to_int64 owner)
+        (Struct.File_lock.describe lk)
   end
 
   module Interrupt = struct
@@ -873,18 +892,34 @@ module In = struct
              (UInt32.to_string flags)
              (UInt32.to_string rflags)
              (UInt64.to_string lock_owner)
-         | Getxattr _
-         | Setxattr _
-         | Listxattr _
-         | Removexattr _
-         | Getlk _
-         | Setlk _
-         | Setlkw _
-         | Link (_,_)
-         | Flush _
-         | Fsyncdir _
-         | Fsync _
-         | Bmap _ -> "FIX ME"
+         | Getxattr r ->
+           let size = getf r Getxattr.T.size in
+           Printf.sprintf "size=%ld"
+             (UInt32.to_int32 size)
+         | Setxattr r ->
+           let size = getf r Setxattr.T.size in
+           let flags = getf r Setxattr.T.flags in
+           Printf.sprintf "size=%ld flags%ld="
+             (UInt32.to_int32 size)
+             (UInt32.to_int32 flags)
+         | Listxattr r ->
+           let size = getf r Getxattr.T.size in
+           Printf.sprintf "size=%ld"
+             (UInt32.to_int32 size)
+         | Removexattr name -> name
+         | Getlk t ->
+           Lk.describe t
+         | Setlk t ->
+           Lk.describe t
+         | Setlkw t ->
+           Lk.describe t
+         | Link (l,n) ->
+           let name = Link.name (to_voidp (addr l)) in
+           Printf.sprintf "name=%s %s" name n
+         | Flush _r -> ""
+         | Fsyncdir _r -> ""
+         | Fsync _r -> ""
+         | Bmap _r -> ""
          | Batch_forget b ->
            let forgets = String.concat ", " (List.map (fun forget ->
              let id = getf forget Struct.Forget_one.T.nodeid in

--- a/lib/profuse_7_23.mli
+++ b/lib/profuse_7_23.mli
@@ -860,8 +860,8 @@ module In : sig
       | Releasedir of Release.T.t Ctypes.structure
       | Fsyncdir of Fsync.T.t Ctypes.structure
       | Rmdir of string
-      | Getxattr of Getxattr.T.t Ctypes.structure
-      | Setxattr of Setxattr.T.t Ctypes.structure
+      | Getxattr of Getxattr.T.t Ctypes.structure * string
+      | Setxattr of Setxattr.T.t Ctypes.structure * string
       | Listxattr of Getxattr.T.t Ctypes.structure
       | Removexattr of string
       | Access of Access.T.t Ctypes.structure

--- a/lib/profuse_7_8.mli
+++ b/lib/profuse_7_8.mli
@@ -798,8 +798,8 @@ module In : sig
       | Releasedir of Release.T.t Ctypes.structure
       | Fsyncdir of Fsync.T.t Ctypes.structure
       | Rmdir of string
-      | Getxattr of Getxattr.T.t Ctypes.structure
-      | Setxattr of Setxattr.T.t Ctypes.structure
+      | Getxattr of Getxattr.T.t Ctypes.structure * string
+      | Setxattr of Setxattr.T.t Ctypes.structure * string
       | Listxattr of Getxattr.T.t Ctypes.structure
       | Removexattr of string
       | Access of Access.T.t Ctypes.structure

--- a/lwt/fuse_lwt.ml
+++ b/lwt/fuse_lwt.ml
@@ -323,8 +323,8 @@ module Dispatch(F : FS_LWT) : FS_LWT with type t = F.t = struct
         | Fsync f -> fsync f req t
         | Write (w, data) -> write w data req t
         | Link (l,name) -> link l name req t
-        | Getxattr g -> getxattr g req t
-        | Setxattr s -> setxattr s req t
+        | Getxattr (g,name) -> getxattr g name req t
+        | Setxattr (s,name) -> setxattr s name req t
         | Listxattr g -> listxattr g req t
         | Removexattr name -> removexattr name req t
         | Access a -> access a req t


### PR DESCRIPTION
Extend 'describe' with support for more messages and tidy up error, string and file handling in the `fusedump` code.
