### PR TITLE
Add notify channel to socket abstraction

### DIFF
--- a/lib/profuse_7_23.ml
+++ b/lib/profuse_7_23.ml
@@ -973,7 +973,7 @@ module Out = struct
       let struct_size = hdrsz
       let size name = hdrsz + (String.length name) + 1
 
-      let create parent filename _req =
+      let create parent filename =
         let code = Hdr.T.Notify_code.fuse_notify_inval_entry in
         let pkt = packet ~code ~count:(size filename) in
         let p = CArray.start pkt in

--- a/lib/profuse_7_23.mli
+++ b/lib/profuse_7_23.mli
@@ -936,8 +936,7 @@ module Out : sig
       val struct_size : int
       val size : string -> int
 
-      val create :
-        Unsigned.UInt64.t -> string -> 'a request -> char Ctypes.CArray.t
+      val create : Unsigned.UInt64.t -> string -> char Ctypes.CArray.t
     end
 
     type t =

--- a/lwt/fuse_lwt.mli
+++ b/lwt/fuse_lwt.mli
@@ -33,6 +33,8 @@ type socket
 val new_socket :
   read:(int -> Unsigned.uint8 Ctypes.CArray.t Lwt.t) ->
   write:(Unsigned.uint8 Ctypes.ptr -> int -> int Lwt.t) ->
+  nwrite:(Unsigned.uint8 Ctypes.ptr -> int -> int Lwt.t) ->
+  nread:(unit -> Unsigned.uint32 Lwt.t) ->
   socket
 
 val socket_id : socket -> int
@@ -43,8 +45,14 @@ val read_socket : socket -> (int -> Unsigned.uint8 Ctypes.CArray.t Lwt.t)
 
 val write_socket : socket -> (Unsigned.uint8 Ctypes.ptr -> int -> int Lwt.t)
 
+val nwrite_socket : socket -> (Unsigned.uint8 Ctypes.ptr -> int -> int Lwt.t)
+
+val nread_socket : socket -> Unsigned.uint32 Lwt.t
+
 val set_socket :
   int ->
   ?read:(int -> Unsigned.uint8 Ctypes.CArray.t Lwt.t) ->
   ?write:(Unsigned.uint8 Ctypes.ptr -> int -> int Lwt.t) ->
+  ?nwrite:(Unsigned.uint8 Ctypes.ptr -> int -> int Lwt.t) ->
+  ?nread:(unit -> Unsigned.uint32 Lwt.t) ->
   unit -> unit


### PR DESCRIPTION
Notify channels need to be separate from FUSE client-server channels because they may error on write and the device write can acquire kernel locks.

/cc @yallop 
