### PR TITLE
nodes: improve the rename callback to include parent metadata

### DIFF
--- a/lib/nodes.mli
+++ b/lib/nodes.mli
@@ -62,7 +62,7 @@ module type METADATA = sig
 
   val to_path : t -> string list
   val create_child : t -> string -> t
-  val rename : t -> string list -> t
+  val rename : t -> t -> string -> t
 end
 
 module Path(Metadata : METADATA)


### PR DESCRIPTION
Also, simplify path handling during rename by relying on the metadata module to correctly compute renamed paths.

This seems so obvious and simpler in retrospect... I'm wary that it's a pure win without defects due to the complexity of the node table in general and rename in particular. Please take a look, @yallop.