### PR TITLE
nodes: add preload function to create children with specific metadata

### DIFF
--- a/lib/nodes.mli
+++ b/lib/nodes.mli
@@ -85,7 +85,7 @@ module Make(N : NODE) : sig
     val free  : t -> fh -> unit
   end
 
-  val preload : N.t node -> string -> (N.v -> N.v) -> unit
+  val preload : N.t node -> string -> (N.v -> N.v) -> N.t node
   val lookup : N.t node -> string -> N.t node
   val handles : N.t node -> (fh * N.h) list
   val rename : N.t node -> string -> N.t node -> string -> unit

--- a/lib/nodes.mli
+++ b/lib/nodes.mli
@@ -85,6 +85,7 @@ module Make(N : NODE) : sig
     val free  : t -> fh -> unit
   end
 
+  val preload : N.t node -> string -> (N.v -> N.v) -> unit
   val lookup : N.t node -> string -> N.t node
   val handles : N.t node -> (fh * N.h) list
   val rename : N.t node -> string -> N.t node -> string -> unit


### PR DESCRIPTION
`preload` lets the caller decide how metadata should be set on soon-to-be children without incrementing the lookup count.

There is almost certainly a better set of functions to manipulate these values (no `map`??) but I'm still not certain that we have a firm idea of the operations required. @yallop please review.