### PR TITLE
Add DELETE and INVAL_INODE notifications

### DIFF
--- a/lib/profuse_7_23.ml
+++ b/lib/profuse_7_23.ml
@@ -403,7 +403,7 @@ module In = struct
       Printf.sprintf "fh=%Ld owner=%Ld lk=(%s) lk_flags=%Ld"
         fh (UInt64.to_int64 owner)
         (Struct.File_lock.describe lk)
-	(UInt32.to_int64 lk_flags)
+        (UInt32.to_int64 lk_flags)
   end
 
   module Interrupt = struct

--- a/lib/profuse_7_23.ml
+++ b/lib/profuse_7_23.ml
@@ -1082,9 +1082,9 @@ module Out = struct
         setf s T.parent  parent;
         setf s T.child   child;
         setf s T.namelen (UInt32.of_int (String.length filename));
-        let sp = ref (p +@ hdrsz) in
-        (* TODO: better copy *)
-        String.iter (fun c -> !sp <-@ c; sp := !sp +@ 1) filename;
+        Memcpy.(unsafe_memcpy ocaml_bytes pointer)
+          ~src:(Bytes.of_string filename) ~src_off:0
+          ~dst:p ~dst_off:hdrsz ~len:(String.length filename);
         pkt
 
       let name p =

--- a/lib/profuse_7_23.ml
+++ b/lib/profuse_7_23.ml
@@ -1047,8 +1047,38 @@ module Out = struct
         Printf.sprintf "under %Ld" (UInt64.to_int64 (getf pkt T.parent))
     end
 
+    module Delete = struct
+      module T = T.Notify_delete
+
+      let hdrsz = sizeof T.t
+      let struct_size = hdrsz
+      let size name = hdrsz + (String.length name) + 1
+
+      let create parent child filename =
+        let code = Hdr.T.Notify_code.fuse_notify_delete in
+        let pkt = packet ~code ~count:(size filename) in
+        let p = CArray.start pkt in
+        let s = !@ (coerce (ptr char) (ptr T.t) p) in
+        setf s T.parent  parent;
+        setf s T.child   child;
+        setf s T.namelen (UInt32.of_int (String.length filename));
+        let sp = ref (p +@ hdrsz) in
+        (* TODO: better copy *)
+        String.iter (fun c -> !sp <-@ c; sp := !sp +@ 1) filename;
+        pkt
+
+      let name p =
+        (* TODO: check namelen valid? *)
+        coerce (ptr char) string ((from_voidp char p) +@ struct_size)
+
+      let describe pkt =
+        Printf.sprintf "as %Ld / %Ld"
+          (UInt64.to_int64 (getf pkt T.parent))
+          (UInt64.to_int64 (getf pkt T.child))
+    end
+
     type t =
-      | Delete (* TODO: do *)
+      | Delete of string * Delete.T.t structure
       | Inval_entry of string * Inval_entry.T.t structure
       | Inval_inode (* TODO: do *)
       | Poll (* TODO: do *)
@@ -1060,7 +1090,10 @@ module Out = struct
       assert (unique = 0_L); (* TODO: really?? *)
       let code = Hdr.Notify_code.of_int32 (getf hdr Hdr.T.error) in
       { chan; hdr; pkt=(match code with
-          | `FUSE_NOTIFY_DELETE -> Delete
+          | `FUSE_NOTIFY_DELETE ->
+            let name = Delete.name p in
+            let s = !@ (from_voidp Delete.T.t p) in
+            Delete (name, s)
           | `FUSE_NOTIFY_INVAL_INODE -> Inval_inode
           | `FUSE_NOTIFY_POLL -> Poll
           | `FUSE_NOTIFY_RETRIEVE -> Retrieve
@@ -1073,7 +1106,8 @@ module Out = struct
 
     let describe ({ chan; pkt }) =
       match pkt with
-      | Delete -> "DELETE FIXME" (* TODO: more *)
+      | Delete (name, d) ->
+        Printf.sprintf "DELETE %s %s" name (Delete.describe d)
       | Inval_entry (name, i) ->
         Printf.sprintf "INVAL_ENTRY %s %s" name (Inval_entry.describe i)
       | Inval_inode -> "INVAL_INODE FIXME" (* TODO: more *)

--- a/lib/profuse_7_23.mli
+++ b/lib/profuse_7_23.mli
@@ -17,6 +17,7 @@ module Types : sig
     open Out
     module Hdr : Hdr
     module Notify_inval_entry : Notify_inval_entry
+    module Notify_inval_inode : Notify_inval_inode
     module Notify_delete : Notify_delete
     module Write : Write
     module Open : Open
@@ -415,6 +416,12 @@ module Out : sig
       val create : Unsigned.UInt64.t -> string -> char Ctypes.CArray.t
     end
 
+    module Inval_inode : sig
+      module T = T.Notify_inval_inode
+
+      val create : Unsigned.UInt64.t -> int64 -> int64 -> char Ctypes.CArray.t
+    end
+
     module Delete : sig
       module T = T.Notify_delete
 
@@ -429,7 +436,7 @@ module Out : sig
     type t =
       | Delete of string * Delete.T.t structure
       | Inval_entry of string * Inval_entry.T.t structure
-      | Inval_inode (* TODO: do *)
+      | Inval_inode of Inval_inode.T.t structure
       | Poll (* TODO: do *)
       | Retrieve (* TODO: do *)
       | Store (* TODO: do *)

--- a/lib/profuse_7_23.mli
+++ b/lib/profuse_7_23.mli
@@ -17,6 +17,7 @@ module Types : sig
     open Out
     module Hdr : Hdr
     module Notify_inval_entry : Notify_inval_entry
+    module Notify_delete : Notify_delete
     module Write : Write
     module Open : Open
     module Init : Init
@@ -414,8 +415,19 @@ module Out : sig
       val create : Unsigned.UInt64.t -> string -> char Ctypes.CArray.t
     end
 
+    module Delete : sig
+      module T = T.Notify_delete
+
+      val struct_size : int
+      val size : string -> int
+
+      val create :
+        Unsigned.UInt64.t -> Unsigned.UInt64.t -> string ->
+        char Ctypes.CArray.t
+    end
+
     type t =
-      | Delete (* TODO: do *)
+      | Delete of string * Delete.T.t structure
       | Inval_entry of string * Inval_entry.T.t structure
       | Inval_inode (* TODO: do *)
       | Poll (* TODO: do *)

--- a/lib/profuse_signatures.ml
+++ b/lib/profuse_signatures.ml
@@ -674,6 +674,15 @@ struct
       val namelen : (Unsigned.UInt32.t, t structure) Ctypes.field
     end
 
+    module type Notify_delete = sig
+      type t
+      val t : t structure Ctypes.typ
+
+      val parent  : (Unsigned.UInt64.t, t structure) Ctypes.field
+      val child   : (Unsigned.UInt64.t, t structure) Ctypes.field
+      val namelen : (Unsigned.UInt32.t, t structure) Ctypes.field
+    end
+
     module type Write = Write
     module type Open_flags = sig
       include Open_flags

--- a/lib/profuse_signatures.ml
+++ b/lib/profuse_signatures.ml
@@ -674,6 +674,15 @@ struct
       val namelen : (Unsigned.UInt32.t, t structure) Ctypes.field
     end
 
+    module type Notify_inval_inode = sig
+      type t
+      val t : t structure Ctypes.typ
+
+      val ino : (Unsigned.UInt64.t, t structure) Ctypes.field
+      val off : (Signed.Int64.t, t structure) Ctypes.field
+      val len : (Signed.Int64.t, t structure) Ctypes.field
+    end
+
     module type Notify_delete = sig
       type t
       val t : t structure Ctypes.typ


### PR DESCRIPTION
The `NOTIFY_DELETE` commit has been carried on the `fuse-7.23` branch for a long time but the `NOTIFY_INVAL_INODE` commit is new and required for attribute and page cache invalidation.