### PR TITLE
Nodes: fix the lookup count to 0 (not 1) when preloads materialize a node

### DIFF
--- a/lib/nodes.ml
+++ b/lib/nodes.ml
@@ -270,7 +270,7 @@ module Make(N : NODE) = struct
                     name space.label
                  ))
     with Not_found ->
-      let node = new_child parent name in
+      let node = { (new_child parent name) with lookups = 0 } in
       let meta = N.value node.data in
       let node = { node with data = N.with_value node.data (meta_fn meta) } in
       Hashtbl.replace table node.id node;


### PR DESCRIPTION
`preload` and `lookup` both use `new_child` which creates a node with 1 lookups but nodes materialized by `preload` have never been looked up by FUSE and so should have 0 lookups.