### PR TITLE
Nodes: add pin and unpin functions to prevent forget GC

### DIFF
--- a/lib/nodes.mli
+++ b/lib/nodes.mli
@@ -26,6 +26,7 @@ type 'a node = {
   data     : 'a;
   children : (string, id) Hashtbl.t;
   lookups  : int;
+  pins     : int;
 }
 and 'a space
 
@@ -89,4 +90,6 @@ module Make(N : NODE) : sig
   val rename : N.t node -> string -> N.t node -> string -> unit
   val unlink : N.t node -> string -> unit
   val store : N.t node -> unit
+  val pin : N.t node -> unit
+  val unpin : N.t node -> unit
 end


### PR DESCRIPTION
Forgetting all lookups on a pinned node will change the generation of the node but not the ID. Completely unpinning an otherwise forgotten node will release the node, remove it from all data structures, and reclaim its ID (with a later generation count).