### PR TITLE
Nodes: fix stale node use in rename

### DIFF
--- a/lib/nodes.ml
+++ b/lib/nodes.ml
@@ -404,8 +404,11 @@ module Make(N : NODE) = struct
     Hashtbl.remove srcpn.children src;
     let srcdeps = srcn.deps + srcn.pins in
     undep srcdeps srcpn;
+    let destpn = refresh destpn in
     unlink destpn dest;
+    let destpn = refresh destpn in
     N.rename destpn srcn dest;
+    let destpn = refresh destpn in
     dep srcdeps destpn
 
   let forget space id n =


### PR DESCRIPTION
Not all of these refreshes may be strictly necessary (right now). The trickiest case is the first `refresh` which is necessary because `srcpn` and `destpn` may be alises of the same parent (the rename is from one name to another in the same parent directory).