### PR TITLE
Remove lib/profuse_signatures.mli when generation fails.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -66,7 +66,7 @@ lib/profuse_signatures.mli: lib/profuse_signatures.ml
 	ocamlfind ocamlc \
 		-package unix-fcntl,unix-errno,unix-sys-stat,unix-dirent \
 		-package unix-unistd,ctypes -i \
-		lib/profuse_signatures.ml >> $@
+		lib/profuse_signatures.ml >> $@ || (rm -f $@ && false)
 
 test: build
 	$(OCAMLBUILD) lib_test/test.native


### PR DESCRIPTION
Currently, when generation of `lib/profuse_signatures.mli` fails (e.g. because a required package is missing), the build leaves the partially-generated file in place, causing subsequent builds to fail.  This PR changes the rule to remove the generated file if the generation command exits unsuccessfully.
