### PR TITLE
Nodes: the root node should begin with a primordial lookup

### DIFF
--- a/lib/nodes.ml
+++ b/lib/nodes.ml
@@ -167,7 +167,7 @@ module Make(N : NODE) = struct
           name = "";
           data = space.root;
           children = Hashtbl.create 32;
-          lookups = 0;
+          lookups = 1;
           pins = 0;
           deps = 0;
         } in


### PR DESCRIPTION
This seems to be the case. See <https://github.com/libfuse/libfuse/blob/e572050d3fc3a1d6a08bfd6cd512edfaff48c9d2/lib/fuse.c#L1306> for the official word on the subject.