### PR TITLE
Make request I/O pure and expose the fd

### DIFF
--- a/lib/fuse.mli
+++ b/lib/fuse.mli
@@ -5,6 +5,7 @@ module Nodes = Nodes
 
 type 'a structure = 'a Ctypes_static.structure
 type request = Profuse.In.Message.t Profuse.request
+type response = Profuse.In.Message.t Profuse.response
 
 module type IO = sig
   type 'a t
@@ -35,7 +36,7 @@ end
 
 module type RO_SIMPLE = sig
   module IO : IO
-  type 'a req_handler = request -> 'a -> 'a IO.t
+  type 'a req_handler = request -> 'a -> ('a * response list) IO.t
 
   type t
     
@@ -119,7 +120,7 @@ module type FS_IO = sig
   val negotiate_mount :
     Profuse.In.Init.T.t structure -> request -> t -> (request * t) IO.t
 
-  val dispatch : request -> t -> t IO.t
+  val dispatch : request -> t -> (t * response list) IO.t
 end
 
 module type STATE = sig
@@ -170,7 +171,7 @@ module Support : functor(IO : IO) -> sig
 
   val nodeid : request -> Unsigned.uint64
 
-  val enosys : request -> 'a -> 'a IO.t
+  val enosys : request -> 'a -> ('a * response list) IO.t
 
   val store_entry :
     ?entry_valid:Unsigned.uint64 ->
@@ -187,5 +188,5 @@ module Support : functor(IO : IO) -> sig
     ?attr_valid:Unsigned.uint64 ->
     ?attr_valid_nsec:Unsigned.uint32 ->
     ('a Nodes.node -> (Profuse.Struct.Attr.T.t structure -> unit) IO.t)
-    -> 'a Nodes.node -> request -> unit IO.t
+    -> 'a Nodes.node -> request -> response list IO.t
 end

--- a/lib/profuse_7_23.ml
+++ b/lib/profuse_7_23.ml
@@ -1581,3 +1581,11 @@ module Out = struct
 end
 
 type 'a request = (In.Hdr.T.t, 'a) packet
+
+type 'a response = [
+  | `Reply of ('a request -> char Ctypes.CArray.t)
+  | `Ack
+  | `Drop
+  | `Error of Errno.t * (string -> unit)
+  | `Raise of exn
+]

--- a/lib/profuse_7_23.mli
+++ b/lib/profuse_7_23.mli
@@ -639,3 +639,11 @@ module Out : sig
     val describe : ('a,t) packet -> string
   end
 end
+
+type 'a response = [
+  | `Reply of ('a request -> char Ctypes.CArray.t)
+  | `Ack
+  | `Drop
+  | `Error of Errno.t * (string -> unit)
+  | `Raise of exn
+]

--- a/lwt/fuse_lwt.mli
+++ b/lwt/fuse_lwt.mli
@@ -31,6 +31,7 @@ module Server(M : MOUNT_LWT)(F : FS_LWT)(IO : IO_LWT)
 type socket
 
 val new_socket :
+  fd:Unix.file_descr ->
   read:(int -> Unsigned.uint8 Ctypes.CArray.t Lwt.t) ->
   write:(Unsigned.uint8 Ctypes.ptr -> int -> int Lwt.t) ->
   nwrite:(Unsigned.uint8 Ctypes.ptr -> int -> int Lwt.t) ->
@@ -38,6 +39,8 @@ val new_socket :
   socket
 
 val socket_id : socket -> int
+
+val socket_fd : socket -> Unix.file_descr
 
 val get_socket : int -> socket
 


### PR DESCRIPTION
- Adjusts `dispatch` and helpers so that they do not write to the request fd. Instead, they return lists of writing operations, to be performed by the same outer code that reads from the fd, and calls `dispatch`.
- Exposes the fd in the API.